### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/src/run_callgrind.py
+++ b/src/run_callgrind.py
@@ -14,15 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import print_function
 import subprocess
 import time
 
 pid = subprocess.check_output(['pgrep', '-f', 'wifi_transceiver.py --ros-namespace r0'])
 pid = pid.rstrip()
-print pid
+print(pid)
 
 output = subprocess.check_output(['callgrind_control', '-i', 'on', str(pid)])
-print output
+print(output)
 time.sleep(5)
 subprocess.check_output(['callgrind_control', '-d'])
 subprocess.check_output(['callgrind_control', '-i', 'off', str(pid)])

--- a/src/transform_laser_data.py
+++ b/src/transform_laser_data.py
@@ -16,6 +16,7 @@
 #
 
 from __future__ import division
+from __future__ import print_function
 
 import rospy
 from sensor_msgs.msg import LaserScan
@@ -46,7 +47,7 @@ class TransformLaser(object):
                                                              rospy.Duration(1.0))   # wait for 1 sec
         except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException):
             rospy.logerror('Error getting transform')
-            print "ERROR!"
+            print("ERROR!")
         
     def laser_callback(self, msg):
         self.laser = msg


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.